### PR TITLE
refactor: 키보드 컨트롤러 리팩토링

### DIFF
--- a/src/controllers/keyboard-controller.js
+++ b/src/controllers/keyboard-controller.js
@@ -1,68 +1,35 @@
 "use strict";
 
 import { addFocus, removeFocus } from "../handlers/focus-handler.js";
+import moveToNextFocus from "../handlers/keyboard-handler.js";
 import isMobile from "../handlers/mobile-recognizer.js";
 import scrollToSection from "../handlers/section-scroller.js";
-
-const handleKeyDown = (event) => {
-  const focusableElements = document.querySelectorAll(".focusable");
-  const focusableArray = Array.from(focusableElements);
-  navigateToElements(event, focusableArray);
-};
-
-const navigateToElements = (event, focusableArray) => {
-  const currentIndex = focusableArray.findIndex(
-    (element) => element === document.activeElement
-  );
-  let nextIndex = 0;
-
-  event.preventDefault();
-
-  switch (event.key) {
-    case "ArrowUp":
-      nextIndex = currentIndex - 1;
-      break;
-    case "ArrowDown":
-      nextIndex = currentIndex + 1;
-      break;
-    case "ArrowLeft":
-      nextIndex = currentIndex - 1;
-      break;
-    case "ArrowRight":
-      nextIndex = currentIndex + 1;
-      break;
-    case "Tab":
-      nextIndex = currentIndex + 1;
-      break;
-    default:
-      return;
-  }
-
-  if (nextIndex < 0) nextIndex = focusableArray.length - 1;
-  else if (nextIndex >= focusableArray.length) nextIndex = 0;
-
-  const nextElement = focusableArray[nextIndex];
-  removeFocus(focusableArray[currentIndex]);
-  addFocus(nextElement);
-};
 
 const addKeyboardController = () => {
   if (isMobile()) return;
 
   const focusableElements = document.querySelectorAll(".focusable");
-  focusableElements.forEach((element) => {
+  const focusableArray = Array.from(focusableElements);
+
+  focusableArray.map((element) => {
     const handleOnMouse = () => {
       addFocus(element);
     };
-
-    const handleFocus = (event) => {
-      const sectionId = event.target.closest("section")?.id;
-      if (sectionId) scrollToSection(sectionId);
+    const handleFocus = (e) => {
+      const sectionId = e.target.closest("section")?.id;
+      sectionId && scrollToSection(sectionId);
       addFocus(element);
     };
     const handleBlur = () => {
       removeFocus(element);
     };
+
+    const handleKeyDown = (e) => {
+      const [prevFocus, newFocus] = moveToNextFocus(e, focusableArray);
+      removeFocus(prevFocus);
+      addFocus(newFocus);
+    };
+
     element.removeEventListener("mousemove", handleOnMouse);
     element.removeEventListener("mouseleave", handleBlur);
     element.removeEventListener("focus", handleFocus);

--- a/src/handlers/keyboard-handler.js
+++ b/src/handlers/keyboard-handler.js
@@ -1,0 +1,37 @@
+const moveToNextFocus = (event, focusableArray) => {
+  const currentIndex = focusableArray.findIndex(
+    (element) => element === document.activeElement
+  );
+  let nextIndex = 0;
+
+  event.preventDefault();
+
+  switch (event.key) {
+    case "ArrowUp":
+      nextIndex = currentIndex - 1;
+      break;
+    case "ArrowDown":
+      nextIndex = currentIndex + 1;
+      break;
+    case "ArrowLeft":
+      nextIndex = currentIndex - 1;
+      break;
+    case "ArrowRight":
+      nextIndex = currentIndex + 1;
+      break;
+    case "Tab":
+      nextIndex = currentIndex + 1;
+      break;
+    default:
+      return;
+  }
+
+  if (nextIndex < 0) nextIndex = focusableArray.length - 1;
+  else if (nextIndex >= focusableArray.length) nextIndex = 0;
+
+  const prevElement = focusableArray[currentIndex];
+  const nextElement = focusableArray[nextIndex];
+  return [prevElement, nextElement];
+};
+
+export default moveToNextFocus;


### PR DESCRIPTION
- 기능 중복하는 코드 삭제
- navigateToElements -> moveToNextFocus로 개명
- moveToNextFocus는 기능 수행만 있어서 핸들러로 분리
- 핸들러에서 focus 처리하면 의존성 중복 -> 컨트롤러가 처리하게 변경