### PR TITLE
fix: 키보드 모드 - 마우스 모드 이벤트 분리

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -162,7 +162,8 @@ img[src=""] {
   cursor: pointer;
 }
 
-.header-nav-list__item.focus {
+.header-nav-list__item.focus,
+.header-nav-list__item:hover {
   color: var(--primary-color);
 }
 
@@ -204,11 +205,13 @@ img[src=""] {
   color: var(--primary-color);
 }
 
-.about__nav:not(.focus) {
+.about__nav:not(.focus),
+.about__nav:not(:hover) {
   animation: flash 2s ease infinite;
 }
 
-.about__nav.focus {
+.about__nav.focus,
+.about__nav:hover {
   animation: pulse 0.3s ease-in-out;
 }
 
@@ -663,7 +666,8 @@ img[src=""] {
   font-size: var(--title-size-l);
 }
 
-.project-content__selection__item.focus {
+.project-content__selection__item.focus,
+.project-content__selection__item:hover {
   transform: translateX(10px);
 }
 
@@ -678,7 +682,9 @@ img[src=""] {
 }
 
 .project-content__selection__item.focus::before,
-.project-box__info__item.focus::before {
+.project-box__info__item.focus::before,
+.project-content__selection__item:hover::before,
+.project-box__info__item:hover:before {
   opacity: 1;
 }
 

--- a/src/controllers/keyboard-controller.js
+++ b/src/controllers/keyboard-controller.js
@@ -12,9 +12,6 @@ const addKeyboardController = () => {
   const focusableArray = Array.from(focusableElements);
 
   focusableArray.map((element) => {
-    const handleOnMouse = () => {
-      addFocus(element);
-    };
     const handleFocus = (e) => {
       const sectionId = e.target.closest("section")?.id;
       sectionId && scrollToSection(sectionId);
@@ -23,7 +20,6 @@ const addKeyboardController = () => {
     const handleBlur = () => {
       removeFocus(element);
     };
-
     const handleKeyDown = (e) => {
       const [prevFocus, newFocus] = moveToNextFocus(e, focusableArray);
       if (!prevFocus) return;
@@ -31,14 +27,10 @@ const addKeyboardController = () => {
       addFocus(newFocus);
     };
 
-    element.removeEventListener("mousemove", handleOnMouse);
-    element.removeEventListener("mouseleave", handleBlur);
     element.removeEventListener("focus", handleFocus);
     element.removeEventListener("blur", handleBlur);
     element.removeEventListener("keydown", handleKeyDown);
 
-    element.addEventListener("mousemove", handleOnMouse);
-    element.addEventListener("mouseleave", handleBlur);
     element.addEventListener("focus", handleFocus);
     element.addEventListener("blur", handleBlur);
     element.addEventListener("keydown", handleKeyDown);

--- a/src/project/Selection.js
+++ b/src/project/Selection.js
@@ -110,7 +110,6 @@ const addEventProjectItem = (project) => {
       projectSkillList.appendChild(projectSkillItem);
       setProjectImage(projectTitle);
     });
-
     play(selectSound);
   };
 
@@ -119,7 +118,10 @@ const addEventProjectItem = (project) => {
     projectSkillList.innerHTML = "";
     clearProjectImage();
   };
-
+  //? 마우스 모드일 땐 focus는 안 하고 이벤트만 실행
+  project.addEventListener("mouseover", handleFocus);
+  project.addEventListener("mouseout", handleBlur);
+  //? 키보드 모드일 땐 focusing도 처리
   addFocusHandler(project)(handleFocus);
   addBlurHandler(project)(handleBlur);
   addClickAndEnterHandler(project)(startProject);


### PR DESCRIPTION
- 포커스마다 스크롤 자동 조절은 마우스 모드에선 UX 저하
- CSS는 hover 추가
- DOM 조작 관련에는 mouseover, mouseout 이벤트 등록
- keyboard-controller에서 마우스 이벤트 등록 코드 삭제
  - 키보드 컨트롤러인데 마우스까지 하는 건 부자연