### PR TITLE
fix: 컴포넌트 렌더 시점 변경

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,12 @@ import renderSelection from "./project/index.js";
 import { restoreFocus } from "./handlers/focus-saver.js";
 import setupSound from "./controllers/sound-controller.js";
 
-window.addEventListener("load", () => {
+window.addEventListener("DOMContentLoaded", () => {
   renderSelection();
   isMobile() && MobileHeader();
+});
+
+window.addEventListener("load", () => {
   setupMuteButton(setupSound);
   setupThemeButton();
   navigateWithScroll();


### PR DESCRIPTION
- 모바일 환경에선 프로젝트가 늦게 렌더됨
- 컴포넌트 생성 시점을 load ->  DOM 트리 생성 직후로 변경