### PR TITLE
fix: 키보드 핸들러 switch 문 변경

### DIFF
--- a/src/handlers/keyboard-handler.js
+++ b/src/handlers/keyboard-handler.js
@@ -28,7 +28,7 @@ const moveToNextFocus = (event) => {
       nextIndex = currentIndex + 1;
       break;
     default:
-      break;
+      return;
   }
 
   if (nextIndex < 0) nextIndex = focusableArray.length - 1;


### PR DESCRIPTION
- break -> return으로 변경
- break로 하면 남은 코드를 실행해서 의도치 않은 이동 발생