### PR TITLE
fix: 스크롤 네비게이션, 포커싱 기능 수정

### DIFF
--- a/src/controllers/click-navigator.js
+++ b/src/controllers/click-navigator.js
@@ -1,6 +1,5 @@
 "use strict";
 
-import addEventForClickAndEnter from "../handlers/click-enter-handler.js";
 import scrollToSection from "../handlers/section-scroller.js";
 
 const navigateWithScroll = () => {
@@ -9,11 +8,37 @@ const navigateWithScroll = () => {
   const [aboutLink, projectLink, contactLink] = tabs;
   const navToProject = document.querySelector(".about__nav");
 
-  addEventForClickAndEnter(homeLogo)(scrollToSection, "home");
-  addEventForClickAndEnter(aboutLink)(scrollToSection, "about");
-  addEventForClickAndEnter(projectLink)(scrollToSection, "project");
-  addEventForClickAndEnter(contactLink)(scrollToSection, "contact");
-  addEventForClickAndEnter(navToProject)(scrollToSection, "project");
+  homeLogo.addEventListener("click", () => {
+    scrollToSection("home");
+  });
+  aboutLink.addEventListener("click", () => {
+    scrollToSection("about");
+  });
+  projectLink.addEventListener("click", () => {
+    scrollToSection("project");
+  });
+  contactLink.addEventListener("click", () => {
+    scrollToSection("contact");
+  });
+  navToProject.addEventListener("click", () => {
+    scrollToSection("project");
+  });
+
+  homeLogo.addEventListener("keydown", ({ key }) => {
+    if (key === "Enter") scrollToSection("home", true);
+  });
+  aboutLink.addEventListener("keydown", ({ key }) => {
+    if (key === "Enter") scrollToSection("about", true);
+  });
+  projectLink.addEventListener("keydown", ({ key }) => {
+    if (key === "Enter") scrollToSection("project", true);
+  });
+  contactLink.addEventListener("keydown", ({ key }) => {
+    if (key === "Enter") scrollToSection("contact", true);
+  });
+  navToProject.addEventListener("keydown", ({ key }) => {
+    if (key === "Enter") scrollToSection("project", true);
+  });
 };
 
 export default navigateWithScroll;

--- a/src/controllers/keyboard-controller.js
+++ b/src/controllers/keyboard-controller.js
@@ -9,7 +9,6 @@ const addKeyboardController = () => {
   if (isMobile()) return;
 
   const focusableElements = document.querySelectorAll(".focusable");
-  const focusableArray = Array.from(focusableElements);
 
   focusableElements.forEach((element) => {
     //? 마우스 클릭 땐 포커스 이벤트 방지
@@ -24,13 +23,18 @@ const addKeyboardController = () => {
     const handleBlur = () => {
       removeFocus(element);
     };
+    const handleHover = () => {
+      removeFocus(document.activeElement);
+    };
 
     element.removeEventListener("mousedown", preventFocusOnClick);
     element.removeEventListener("focus", handleFocus);
     element.removeEventListener("blur", handleBlur);
     element.removeEventListener("keydown", moveToNextFocus);
+    element.removeEventListener("mouseover", handleHover);
 
     element.addEventListener("mousedown", preventFocusOnClick);
+    element.addEventListener("mouseover", handleHover);
     element.addEventListener("focus", handleFocus);
     element.addEventListener("blur", handleBlur);
     element.addEventListener("keydown", moveToNextFocus);

--- a/src/handlers/section-scroller.js
+++ b/src/handlers/section-scroller.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import { addFocus } from "./focus-handler.js";
+
 const calcCenterPositionOfSection = (section) => {
   const windowHeight = window.innerHeight;
   const headerHeight = document.querySelector("header").offsetHeight;
@@ -16,20 +18,27 @@ const contact = document.getElementById("contact");
 const ABOUT_POSITION = calcCenterPositionOfSection(about);
 const PROJECT_POSITION = calcCenterPositionOfSection(project);
 const CONTACT_POSITION = calcCenterPositionOfSection(contact);
+const focusOnFirstItem = (section) => {
+  addFocus(section.querySelector(".focusable"));
+};
 
-const scrollToSection = (sectionId) => {
+const scrollToSection = (sectionId, isEnter) => {
   switch (sectionId) {
     case "about":
       scrollTo(0, ABOUT_POSITION);
+      isEnter && focusOnFirstItem(about);
       break;
     case "project":
       scrollTo(0, PROJECT_POSITION);
+      isEnter && focusOnFirstItem(project);
       break;
     case "contact":
       scrollTo(0, CONTACT_POSITION);
+      isEnter && focusOnFirstItem(contact);
       break;
     case "home":
       scrollTo(0, 0);
+      isEnter && focusOnFirstItem(document);
       break;
     default:
       break;


### PR DESCRIPTION
- 키보드 엔터로 누르면 해당 섹션의 첫 번째 아이템으로 포커싱
- 마우스로 누르면 스크롤 이동만
- 프로젝트 화면에서도 마우스로 hover하면 키보드 모드의 focus 해제